### PR TITLE
Add --delimiter option for 'listpages' and 'getpagesummary'

### DIFF
--- a/confluence.py
+++ b/confluence.py
@@ -207,6 +207,7 @@ def Parser():
 
     parser_listpages = subparsers.add_parser('listpages', help='List pages in one or all spaces')
     parser_listpages.add_argument("-s", "--spacekey", help="Space Key", default="")
+    parser_listpages.add_argument("-d", "--delimiter", help="Field delimiter", default=", ")
 
     parser_removepage = subparsers.add_parser('removepage', help='Remove a page')
     parser_removepage.add_argument("-n", "--name", help="Page name", required=True)
@@ -219,6 +220,7 @@ def Parser():
     parser_getpagesummary = subparsers.add_parser('getpagesummary', help='Get page summary')
     parser_getpagesummary.add_argument("-s", "--spacekey", help="Space Key", required=True)
     parser_getpagesummary.add_argument("-n", "--name", help="Page name", required=True)
+    parser_getpagesummary.add_argument("-d", "--delimiter", help="Field delimiter", default=", ")
 
     parser_listspaces = subparsers.add_parser('listspaces', help='List all spaces')
 
@@ -319,7 +321,7 @@ def Actions(token,xml_server,args,content):
 
         elif args.action == "getpagesummary":
             page = ConfluencePage(token,xml_server,args.name,args.spacekey,content).get()
-            print(("%s, %s, %s, %s, %s") % (
+            print args.delimiter.join((
              page['id'], page['space'], page['parentId'], page['title'], page['url']))
 
         elif args.action == "listpages":
@@ -330,7 +332,7 @@ def Actions(token,xml_server,args,content):
             for space in spaces:
                 all_pages = ConfluenceSpace(token,xml_server).get_all_pages(space['key'])
                 for page in all_pages:
-                    print(("%s, %s, %s, %s, %s") % (
+                    print args.delimiter.join((
                      page['id'], page['space'], page['parentId'], page['title'], page['url']))
        
         elif args.action == "removepage":


### PR DESCRIPTION
Both of these actions used to have ", " as a hard-coded field
delimiter. This made it difficult to process the output if, eg.,
a page name had ", " in it. The new --delimiter option makes it
possible to use an arbitrary string as field delimiter, instead.

The delimiter defaults to ", " to avoid breaking things for
existing users.